### PR TITLE
RF-17649 Remove the check for max allowed numRects value

### DIFF
--- a/vncclient/server_messages.go
+++ b/vncclient/server_messages.go
@@ -56,9 +56,6 @@ func (*FramebufferUpdateMessage) Read(c *ClientConn, r io.Reader) (ServerMessage
 	if err := binary.Read(r, binary.BigEndian, &numRects); err != nil {
 		return nil, err
 	}
-    if numRects > 2000 {
-        return nil, errors.Errorf("excessive rectangle count %d", int(numRects));
-    }
 
 	// Build the map of encodings supported
 	encMap := make(map[int32]Encoding)


### PR DESCRIPTION
We're still getting messages with many rects (I've seen >4k [here](https://sentry.io/organizations/rainforest/issues/1569413967/?project=1379246&query=is%3Aunresolved+attributeError&statsPeriod=14d)). The purpose of this check is not clear, so let's remove it and see what happens. From reading the code, it seems like the worst thing might be allocating ~41MB of memory, but that doesn't seem terrible.